### PR TITLE
Make find commands check partial matches

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -39,6 +39,22 @@ public class StringUtil {
     }
 
     /**
+     * Returns true if the {@code sentence} contains the {@code word}.
+     * Ignores case, full word match not required.
+     * @param sentence cannot be null
+     * @param word cannot be null, cannot be empty
+     */
+    public static boolean containsPartialWordIgnoreCase(String sentence, String word) {
+        requireNonNull(sentence);
+        requireNonNull(word);
+
+        String preppedWord = word.trim();
+        checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
+
+        return sentence.toLowerCase().contains(preppedWord.toLowerCase());
+    }
+
+    /**
      * Returns a detailed message of the t, including the stack trace.
      */
     public static String getDetails(Throwable t) {

--- a/src/main/java/seedu/address/model/person/DepartmentContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/DepartmentContainsKeywordsPredicate.java
@@ -21,11 +21,13 @@ public class DepartmentContainsKeywordsPredicate implements Predicate<Person> {
         if (person instanceof Patient) {
             Patient patient = (Patient) person;
             return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(patient.getDepartment().toString(), keyword));
+                .anyMatch(keyword -> StringUtil.containsPartialWordIgnoreCase(patient.getDepartment()
+                    .toString(), keyword));
         } else if (person instanceof HealthcareStaff) {
             HealthcareStaff staff = (HealthcareStaff) person;
             return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(staff.getDepartment().toString(), keyword));
+                .anyMatch(keyword -> StringUtil.containsPartialWordIgnoreCase(staff.getDepartment()
+                    .toString(), keyword));
         }
         return false;
     }

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsPartialWordIgnoreCase(person.getName().fullName, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/ProviderRoleContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/ProviderRoleContainsKeywordPredicate.java
@@ -23,7 +23,7 @@ public class ProviderRoleContainsKeywordPredicate implements Predicate<Person> {
         }
         HealthcareStaff staff = (HealthcareStaff) person;
         return keywords.stream()
-            .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(staff.getProviderRole().toString(), keyword));
+            .anyMatch(keyword -> StringUtil.containsPartialWordIgnoreCase(staff.getProviderRole().toString(), keyword));
     }
 
     @Override


### PR DESCRIPTION
`find`, `finddep` and `findstaff` commands now check for partial matches, so users no longer need to type the whole name, department or provider role.

closes #140, #143, #144 