### PR TITLE
Add CLI Command to toggle between Dark and Light Mode

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -19,13 +19,17 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** The theme should be toggled. */
+    private final boolean toggleTheme;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean toggleTheme) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
+        this.toggleTheme = toggleTheme;
     }
 
     /**
@@ -33,7 +37,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+        this(feedbackToUser, false, false, false);
     }
 
     public String getFeedbackToUser() {
@@ -42,6 +46,10 @@ public class CommandResult {
 
     public boolean isShowHelp() {
         return showHelp;
+    }
+
+    public boolean isToggleTheme() {
+        return toggleTheme;
     }
 
     public boolean isExit() {
@@ -62,12 +70,13 @@ public class CommandResult {
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit;
+                && exit == otherCommandResult.exit
+                && toggleTheme == otherCommandResult.toggleTheme;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit);
+        return Objects.hash(feedbackToUser, showHelp, exit, toggleTheme);
     }
 
     @Override
@@ -76,6 +85,7 @@ public class CommandResult {
                 .add("feedbackToUser", feedbackToUser)
                 .add("showHelp", showHelp)
                 .add("exit", exit)
+                .add("toggleTheme", toggleTheme)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -20,6 +20,7 @@ public enum CommandType {
     EXIT,
     REMARK,
     SELECT,
+    TOGGLETHEME,
     UNKNOWN;
 
     /**
@@ -46,6 +47,7 @@ public enum CommandType {
         case "help", "h" -> HELP;
         case "exit", "quit" -> EXIT;
         case "select", "s" -> SELECT;
+        case "toggletheme", "tt" -> TOGGLETHEME;
         default -> UNKNOWN;
         };
     }

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -5,7 +5,6 @@ import seedu.address.model.Model;
 /**
  * Format full help instructions for every command for display.
  */
-
 public class HelpCommand extends Command {
 
     public static final CommandType COMMAND_TYPE = CommandType.HELP;
@@ -17,7 +16,7 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
     }
 }
 

--- a/src/main/java/seedu/address/logic/commands/ToggleThemeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ToggleThemeCommand.java
@@ -1,0 +1,19 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+
+/**
+ * Toggle the Ui Theme
+ */
+public class ToggleThemeCommand extends Command {
+
+    public static final CommandType COMMAND_TYPE = CommandType.TOGGLETHEME;
+
+    public static final String MESSAGE_TOGGLE_THEME_ACKNOWLEDGEMENT = "Switching Theme as requested ...";
+
+    @Override
+    public CommandResult execute(Model model) {
+        return new CommandResult(MESSAGE_TOGGLE_THEME_ACKNOWLEDGEMENT, false, false, true);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListPatientsCommand;
 import seedu.address.logic.commands.ListStaffCommand;
+import seedu.address.logic.commands.ToggleThemeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -100,6 +101,9 @@ public class AddressBookParser {
 
         case SELECT:
             return new SelectCommandParser().parse(arguments);
+
+        case TOGGLETHEME:
+            return new ToggleThemeCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -198,7 +198,7 @@ public class MainWindow extends UiPart<Stage> {
      * Toggle between Dark Theme and Light Theme
      */
     @FXML
-    public void toggleDarkTheme() {
+    public void handleToggleTheme() {
         isDarkTheme = !isDarkTheme;
         logger.info("Toggling theme. New theme: " + (isDarkTheme ? "Dark" : "Light"));
         updateStyleSheets(isDarkTheme);
@@ -255,6 +255,10 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isExit()) {
                 handleExit();
+            }
+
+            if (commandResult.isToggleTheme()) {
+                handleToggleTheme();
             }
 
             updateSelectionDisplay();

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -22,7 +22,7 @@
       <VBox>
         <MenuBar fx:id="menuBar" prefHeight="0.0" prefWidth="762.0" VBox.vgrow="NEVER">
           <Menu mnemonicParsing="false" text="File">
-            <CheckMenuItem fx:id="darkModeMenuItem" mnemonicParsing="false" onAction="#toggleDarkTheme" text="Dark Mode" />
+            <CheckMenuItem fx:id="darkModeMenuItem" mnemonicParsing="false" onAction="#handleToggleTheme" text="Dark Mode" />
             <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
           </Menu>
           <Menu mnemonicParsing="false" text="Help">

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -14,7 +14,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -29,10 +29,13 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false)));
+
+        // different toggleTheme value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, true)));
     }
 
     @Test
@@ -46,10 +49,13 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false).hashCode());
+
+        // different toggleTheme value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, true).hashCode());
     }
 
     @Test
@@ -57,7 +63,7 @@ public class CommandResultTest {
         CommandResult commandResult = new CommandResult("feedback");
         String expected = CommandResult.class.getCanonicalName() + "{feedbackToUser="
                 + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
-                + ", exit=" + commandResult.isExit() + "}";
+                + ", exit=" + commandResult.isExit() + ", toggleTheme=" + commandResult.isToggleTheme() + "}";
         assertEquals(expected, commandResult.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -14,7 +14,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -14,7 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ToggleThemeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ToggleThemeCommandTest.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.ToggleThemeCommand.MESSAGE_TOGGLE_THEME_ACKNOWLEDGEMENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+
+public class ToggleThemeCommandTest {
+
+    private Model model = new ModelManager();
+    private Model expectedModel = new ModelManager();
+
+    @Test
+    public void execute_toggletheme_success() {
+        CommandResult expectedCommandResult = new CommandResult(
+                MESSAGE_TOGGLE_THEME_ACKNOWLEDGEMENT, false, false, true);
+        assertCommandSuccess(new ToggleThemeCommand(), model, expectedCommandResult, expectedModel);
+    }
+}


### PR DESCRIPTION
Resolve #163 

Implement a CLI command (`toggle-theme` or `tt`) to allow users to quickly toggle between dark and light modes without needing to click through a UI. This will improve workflow efficiency and provide a more seamless user experience.
