### PR TITLE
Allow phone number and email to take in the value NA if not available

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddPatientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPatientCommandParser.java
@@ -49,13 +49,13 @@ public class AddPatientCommandParser implements Parser<AddPatientCommand> {
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = argMultimap.getValue(PREFIX_EMAIL).isEmpty()
-                ? new Email("NA@placeholder.com") : ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+                ? new Email("NA") : ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = argMultimap.getValue(PREFIX_ADDRESS).isEmpty()
                 ? new Address("NA") : ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
-        String docInCharge = argMultimap.getValue(PREFIX_DOCTOR).isEmpty() ? ""
+        String docInCharge = argMultimap.getValue(PREFIX_DOCTOR).isEmpty() ? "NA"
                 : ParserUtil.parseDoctor(argMultimap.getValue(PREFIX_DOCTOR).get());
         String inputNokName = argMultimap.getValue(PREFIX_NOKNAME).orElse("NA");
-        String inputNokPhone = argMultimap.getValue(PREFIX_NOKPHONE).orElse("000");
+        String inputNokPhone = argMultimap.getValue(PREFIX_NOKPHONE).orElse("NA");
         NextOfKin nextOfKin = ParserUtil.parseNextOfKin(inputNokName, inputNokPhone);
         Department department = argMultimap.getValue(PREFIX_DEPARTMENT).isEmpty() ? new Department("NA")
                 : ParserUtil.parseDepartment(argMultimap.getValue(PREFIX_DEPARTMENT).get());

--- a/src/main/java/seedu/address/logic/parser/AddStaffCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddStaffCommandParser.java
@@ -51,7 +51,7 @@ public class AddStaffCommandParser implements Parser<AddStaffCommand> {
             : ParserUtil.parseDepartment(argMultimap.getValue(PREFIX_DEPARTMENT).get());
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        String inputEmail = argMultimap.getValue(PREFIX_EMAIL).orElse("NA@placeholder.com");
+        String inputEmail = argMultimap.getValue(PREFIX_EMAIL).orElse("NA");
         Email email = ParserUtil.parseEmail(inputEmail);
         String inputAddress = argMultimap.getValue(PREFIX_ADDRESS).orElse("NA");
         Address address = ParserUtil.parseAddress(inputAddress);

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Email {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
-    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
+    public static final String MESSAGE_CONSTRAINTS = "Emails can be NA or should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
@@ -29,7 +29,8 @@ public class Email {
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
-    public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
+    public static final String EMAIL_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
+    public static final String VALIDATION_REGEX = "(" + EMAIL_REGEX + "|NA)$";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -11,8 +11,8 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should only contain numbers (at least 3 digits) or be 'NA'";
+    public static final String VALIDATION_REGEX = "(\\d{3,}|NA)";
     public final String value;
 
     /**


### PR DESCRIPTION
- allow email to be `NA` or `name@host` format resolves #134 
- allow phone number to be `NA` or `numbers`
- modify addpatient and addstaff command parser, default value for `email` and `nok_phone` are `NA`